### PR TITLE
Display import_ctf Exceptions via repr

### DIFF
--- a/CTFd/admin/__init__.py
+++ b/CTFd/admin/__init__.py
@@ -70,7 +70,7 @@ def admin_import_ctf():
             import_ctf(backup)
     except Exception as e:
         print(e)
-        errors.append(type(e).__name__)
+        errors.append(repr(e))
 
     if errors:
         return errors[0], 500


### PR DESCRIPTION
- Wraps exceptions on `/admin/import` returned to users in a `repr()`, making debugging easier.